### PR TITLE
Do not run nodejs as root and use a production ready version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,12 @@
-FROM node:latest
+FROM node:12
 
-WORKDIR /usr/src/app
-COPY . .
+RUN mkdir /app && chown -R node:node /app
+WORKDIR /app
+
+USER node
 RUN npm install express
+
+COPY --chown=node:node . .
 
 EXPOSE 8082
 CMD [ "node", "app.js" ]


### PR DESCRIPTION
Title says all.

This is untested, but at a quick glance should be ok.

Not ideal but a quick fix in case this is deployed to the world somewhere.
